### PR TITLE
fix set header to null response when routing chain exists

### DIFF
--- a/lib/stubcell.js
+++ b/lib/stubcell.js
@@ -83,7 +83,7 @@ StubCell.prototype._setupEntry = function(entry) {
     }
     if (isJSONRPC) {
       var match = checkJSONRPC(entryBody, reqBody);
-      if (!match) next(); 
+      if (!match) return next();
     }
     Object.keys(headers).forEach(function(key) {
       res.setHeader(key, headers[key]);


### PR DESCRIPTION
`return` is required :)
