### PR TITLE
support loose compararison between request and entry

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -1,15 +1,49 @@
 var deepEqual = require('deep-equal');
-module.exports.jsonrpc = function(entryBody, reqBody){
+var includeEqual = function(small, large){
+  // request / entry do not use Class so compare loose (e.g. without comparison prototype)
+  if(small === large) return true;
+
+  if(small instanceof Date && large instanceof Date) {
+    return small.getTime() === large.getTime();
+  }
+
+  if(typeof small != 'object' && typeof large != 'object') {
+    return small == large;
+  }
+
+  var attrs = Object.keys(small);
+  for(var i = 0; i < attrs.length; i++) {
+    var attr = attrs[i];
+    if(! includeEqual(small[attr], large[attr])) return false;
+  }
+  return true;
+};
+
+module.exports.jsonrpc = function(entryBody, reqBody, looseCompare){
   var matchMethod = entryBody.method === reqBody.method;
-  var matchParam = entryBody.params ? deepEqual(entryBody.params, reqBody.params) : true;
-  // ignore id check
+  var matchParam = false;
+
+  if (looseCompare) {
+    matchParam = entryBody.params ? includeEqual(entryBody.params, reqBody.params) : true;
+  } else {
+    matchParam = entryBody.params ? deepEqual(entryBody.params, reqBody.params) : true;
+    // ignore id check
+  }
   return matchMethod && matchParam;
 };
 
-module.exports.body = function(entryBody, reqBody){
-  return deepEqual(entryBody, reqBody);
+module.exports.body = function(entryBody, reqBody, looseCompare){
+  if (looseCompare) {
+    return includeEqual(entryBody, reqBody);
+  } else {
+    return deepEqual(entryBody, reqBody);
+  }
 };
 
-module.exports.query = function(entryQuery, reqQuery){
-  return deepEqual(entryQuery, reqQuery);
+module.exports.query = function(entryQuery, reqQuery, looseCompare){
+  if (looseCompare) {
+    return includeEqual(entryQuery, reqQuery);
+  } else {
+    return deepEqual(entryQuery, reqQuery);
+  }
 };

--- a/lib/stubcell.js
+++ b/lib/stubcell.js
@@ -20,6 +20,7 @@ StubCell.prototype.loadEntry = function(entryPath, options) {
   this.basePath = options.basePath || path.dirname(entryPath);
   this.debug = options.debug || false;
   this.record = options.record || {};
+  this.looseCompare = options.looseCompare || false;
 };
 
 StubCell.prototype._parseJSON5 = function(data) {
@@ -137,15 +138,15 @@ StubCell.prototype._setupEntry = function(entry) {
 
     // CHECK request match
     if (isJSONRPC) {
-      var match = check.jsonrpc(entryBody, reqBody);
+      var match = check.jsonrpc(entryBody, reqBody, this.looseCompare);
       if (!match) return next();
     } else {
       if(entry.request.body) {
-        match = check.body(entryBody, reqBody);
+        match = check.body(entryBody, reqBody, this.looseCompare);
         if (!match) return next();
       }
       if(entry.request.query) {
-        match = check.query(entryQuery, reqQuery);
+        match = check.query(entryQuery, reqQuery, this.looseCompare);
         if (!match) return next();
       }
     }

--- a/test/loose.yaml
+++ b/test/loose.yaml
@@ -1,0 +1,17 @@
+-
+  request:
+    url: $finally
+    method: ALL
+  response:
+    status: 200
+    body: '{message:"data lack require params"}'
+-
+  request:
+    url: /loose/:id
+    method: GET
+    query:
+      require1: 1
+      require2: 2
+  response:
+    status: 200
+    body: '{message:"include"}'

--- a/test/test_loose.js
+++ b/test/test_loose.js
@@ -1,0 +1,55 @@
+var StubCell = require("../index");
+var http = require("http");
+var assert = require("power-assert");
+
+var stubcell = new StubCell();
+stubcell.loadEntry(__dirname + "/loose.yaml", {basepath: "", debug: true, looseCompare: true});
+var app = stubcell.server();
+
+describe('Stubcell server with looseCompare', function(){
+  var server;
+  beforeEach(function(done) {
+    server = app.listen(3000);
+    server.on("listening", done);
+  });
+  afterEach(function(done) {
+    server.on("close", done);
+    server.close();
+  });
+  describe("request", function(){
+    it("should return include when request includes entry queries", function(done){
+      http.get("http://localhost:3000/loose/1?require1=1&require2=2&optional=3", function(res){
+        var data = '';
+        res.on("data", function(chunk) {
+          data += chunk;
+        });
+        res.on("end", function() {
+          try {
+            assert.equal(JSON.parse(data).message, "include");
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+      });
+
+    });
+    it("should return 'data lack require params' when request lack entry queries", function(done){
+      http.get("http://localhost:3000/loose/1?require1=1&optional=3", function(res){
+        var data = '';
+        res.on("data", function(chunk) {
+          data += chunk;
+        });
+        res.on("end", function() {
+          try {
+            assert.equal(JSON.parse(data).message, "data lack require params");
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
add loose check option.

when set this option `true`, entry requirement and request query / body are compared loose or return `true`, if request includes entry.

e.g.

``` javascript
console.log(entry.query); // {require1: 1, require2: 2}

console.log(req.query); // {require1: 1, require2: 2, optional: 3} 
check.query(entry.query, req.query, false); // => true

console.log(req.query); // {require1: 1, optional: 3} 
check.query(entry.query, req.query, false); // => false cause `req.query` lacks `require2`
```
