### PR TITLE
Deprecate load entry

### DIFF
--- a/lib/stubcell.js
+++ b/lib/stubcell.js
@@ -17,7 +17,6 @@ function StubCell(entryPath, options) {
 }
 
 StubCell.prototype.loadEntry = function(entryPath, options) {
-  if(!entryPath || !path.existSync(entryPath)) throw new Error("entryPath required");
   this.entries = yaml.load(entryPath);
   options = options || {};
   this.basepath = options.basepath || path.dirname(entryPath);


### PR DESCRIPTION
I think it is better to pass `entryPath` and `options` to `constructor` than to `loadEntry`.

```
stubcell = new Stubcell(entryPath, options);
```

so I want to deprecate `loadEntry`.
