### PR TITLE
set default content-type when accept is */*

### DIFF
--- a/lib/stubcell.js
+++ b/lib/stubcell.js
@@ -141,7 +141,7 @@ StubCell.prototype._execEntry = function(req, res, entry){
   Object.keys(headers).forEach(function(key) {
     res.setHeader(key, headers[key]);
   });
-  res.setHeader('Content-Type', contentType);
+  res.setHeader('Content-Type', contentType === "*/*" ? "text/html" : contentType);
 
   // response data
   res.statusCode = response.status;


### PR DESCRIPTION
When accept in request is "*/*", stubcell did not return value because of absence of content-type.

In this p-r, I set "text/html" to content-type as default value.



