### PR TITLE
Feature/fixed cors preflight

### DIFF
--- a/lib/stubcell.js
+++ b/lib/stubcell.js
@@ -152,17 +152,22 @@ StubCell.prototype._execEntry = function(req, res, entry){
         path.join(this.basepath, response.file) :
       this.fileFromRequest(entryUrl, response.file, req, this.basepath);
 
+  // for cors preflight
   if(this.cors){
-    if(this.cors === true){
-      res.set('Access-Control-Allow-Origin', '*');
-      res.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
-    }else if(typeof this.cors === 'function'){
-      res.set('Access-Control-Allow-Origin',
-              this.cors['Access-Control-Allow-Origin'] || '*');
+    res.set('Access-Control-Allow-Origin',
+            this.cors['Access-Control-Allow-Origin'] ||
+            req.headers.origin);
+    if(this.cors['Access-Control-Allow-Methods'] ||
+       req.headers["access-control-request-method"]){
       res.set('Access-Control-Allow-Methods',
-              this.cors['Access-Control-Allow-Methods'] || 'GET, POST, PUT, DELETE');
-      if(this.cors['Access-Control-Allow-Headers'])
-        res.set('Access-Control-Allow-Methods', this.cors['Access-Control-Allow-Headers']);
+              this.cors['Access-Control-Allow-Methods'] ||
+              req.headers["access-control-request-method"]);
+    }
+    if(this.cors['Access-Control-Allow-Headers'] ||
+       req.headers["access-control-request-headers"]){
+      res.set('Access-Control-Allow-Headers',
+              this.cors['Access-Control-Allow-Headers'] ||
+              req.headers["access-control-request-headers"]);
     }
   }
 

--- a/lib/stubcell.js
+++ b/lib/stubcell.js
@@ -215,8 +215,24 @@ StubCell.prototype._setupEntries = function(entries){
     if(entry){
       return this._execEntry(req, res, entry);
     }
+    if(this.cors && this.isPreflight(req)){
+      return this.preflight(req, res, next);
+    }
     return next();
   }.bind(this));
+};
+
+StubCell.prototype.isPreflight = function(req){
+  return req.method === "OPTIONS" &&
+    req.headers["access-control-request-method"];
+};
+
+StubCell.prototype.preflight = function(req, res, next){
+  res.set('Access-Control-Allow-Origin',  req.headers["origin"]);
+  res.set('Access-Control-Allow-Methods', req.headers["access-control-request-method"]);
+  res.set('Access-Control-Allow-Headers', req.headers["access-control-request-headers"]);
+  res.status(200);
+  res.send("");
 };
 
 StubCell.prototype.fileFromRequest = function(entryUrl, filepath, req, basepath) {

--- a/lib/stubcell.js
+++ b/lib/stubcell.js
@@ -270,7 +270,7 @@ StubCell.prototype.fileFromRequest = function(entryUrl, filepath, req, basepath)
   // if /abc/:id
   if (url.indexOf(":") >= 0) {
     // /abc/:id -> /abc/*
-    temp = url.replace(/:[a-zA-Z0-9]+/g, '*');
+    var temp = url.replace(/:[a-zA-Z0-9]+/g, '*');
     var files = glob.sync(basepath + temp);
     var found = "";
     files.some(function(file) {

--- a/test/test_cors.js
+++ b/test/test_cors.js
@@ -15,6 +15,13 @@ describe('Stubcell server with cors', function(){
     var stubcell = new StubCell();
     stubcell.loadEntry(__dirname + "/cors.yaml", {basepath: "", debug: true, cors: true, port: 4000});
     var app = stubcell.server();
+    var createCorsHeader = function(origin, method, headers){
+      return {
+        "origin": origin,
+        "Access-Control-Request-Method": method,
+        "Access-Control-Request-Headers": typeof headers === "string" ? headers :  headers.join(", ")
+      };
+    };
 
     before(function(done) {
       server = app.listen(4000);
@@ -25,28 +32,47 @@ describe('Stubcell server with cors', function(){
       server.close();
     });
     it("GET request", function(done){
-      request({url: "http://localhost:4000/cors/1", method: "GET", proxy: ""}, function(err, res){
+      request({
+        url: "http://localhost:4000/cors/1",
+        method: "GET",
+        headers: {origin: "http://example.com"},
+        proxy: ""
+      }, function(err, res){
         assert(res.headers["access-control-allow-origin"], "*");
-        assert(res.headers["access-control-allow-methods"], "GET, POST, PUT, DELETE");
         done();
       });
     });
     it("POST request", function(done){
-      request({url: "http://localhost:4000/cors/1", method: "POST", proxy: ""}, function(err, res){
+      request({
+        url: "http://localhost:4000/cors/1",
+        method: "POST",
+        headers: createCorsHeader("http://example.com", "POST", "X-SAMPLE-Timestamp"),
+        proxy: ""
+      }, function(err, res){
         assert(res.headers["access-control-allow-origin"], "*");
         assert(res.headers["access-control-allow-methods"], "GET, POST, PUT, DELETE");
         done();
       });
     });
     it("PUT request", function(done){
-      request({url: "http://localhost:4000/cors/1", method: "PUT", proxy: ""}, function(err, res){
+      request({
+        url: "http://localhost:4000/cors/1",
+        method: "PUT",
+        headers: createCorsHeader("http://example.com", "PUT", "X-SAMPLE-Timestamp"),
+        proxy: ""
+      }, function(err, res){
         assert(res.headers["access-control-allow-origin"], "*");
         assert(res.headers["access-control-allow-methods"], "GET, POST, PUT, DELETE");
         done();
       });
     });
     it("DELETE request", function(done){
-      request({url: "http://localhost:4000/cors/1", method: "DELETE", proxy: ""}, function(err, res){
+      request({
+        url: "http://localhost:4000/cors/1",
+        method: "DELETE",
+        headers: createCorsHeader("http://example.com", "DELETE", "X-SAMPLE-Timestamp"),
+        proxy: ""
+      }, function(err, res){
         assert(res.headers["access-control-allow-origin"], "*");
         assert(res.headers["access-control-allow-methods"], "GET, POST, PUT, DELETE");
         done();


### PR DESCRIPTION
Fixed cors response header as bellow:

1. Access-Control-Allow-Origin: replaced request origin from "*"
2. Access-Control-Allow-Method: replaced request Access-Control-Request-Method from "GET, POST, PUT, DELETE"
3. Access-Control-Allow-Headers: added

And automatically added preflight entry if it does not exist.
