### PR TITLE
Fixed a bug when specify ALL to the method

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -5,6 +5,10 @@ var includeEqual = function(small, large){
   // request / entry do not use Class so compare loose (e.g. without comparison prototype)
   if(small === large) return true;
 
+  if(typeof small !== "undefined" && typeof large === "undefined") {
+    return false;
+  }
+
   if(small instanceof Date && large instanceof Date) {
     return small.getTime() === large.getTime();
   }

--- a/lib/check.js
+++ b/lib/check.js
@@ -37,7 +37,7 @@ var check = module.exports = {
 
   request: function(request, req, looseCompare){
     var parsedUrl = url.parse(req.url);
-    return request.method === "ALL" ? true : request.method.toLowerCase() === req.method.toLowerCase() &&
+    return (request.method === "ALL" ? true : request.method.toLowerCase() === req.method.toLowerCase()) &&
       check.url(request.pathRegexp, parsedUrl.pathname) &&
       check.headers(request.headers, req.headers, looseCompare) &&
       check.query(request.query, req.query, looseCompare) &&


### PR DESCRIPTION
1. If you specify 'ALL' to the method, body and params is ignored.
2. I want to check that the parameters exists in YAML and the request.